### PR TITLE
Update the render ReportQuery script

### DIFF
--- a/scripts/render-reportquery.sh
+++ b/scripts/render-reportquery.sh
@@ -1,14 +1,30 @@
 #! /bin/bash
 
+# TODO:
+# - This script isn't very robust.
+# - Should probably handle inputs better
+# - Need a way to injecting the `inputs` for queries that need to reference non-defaults
+
 set -ue
 
 REPORTQUERY_NAME=${1:?}
-# START=${2:?}
-# END=${3:?}
+REPORTQUERY_NAMESPACE=${2:-$REPORTQUERY_NAMESPACE}
 
-token=$(oc -n $METERING_NAMESPACE sa get-token reporting-operator)
-hostname=$(oc -n $METERING_NAMESPACE get routes metering -o jsonpath={.spec.host})
+start=$(oc -n $REPORTQUERY_NAMESPACE get reportdatasources --no-headers=true | grep -Ev '*-raw|^report' | awk 'NR==1 { print $2 }')
+end=$(oc -n $REPORTQUERY_NAMESPACE get reportdatasources --no-headers=true | grep -Ev '*-raw|^report' | awk 'NR==1 { print $3 }')
+token=$(oc -n $REPORTQUERY_NAMESPACE sa get-token reporting-operator)
+hostname=$(oc -n $REPORTQUERY_NAMESPACE get routes metering -o jsonpath={.spec.host})
 
-curl -w '\n' -k -XPOST -H "Content-Type: application/json" -H "Authorization: Bearer $token" \
-    "https://$hostname/api/v2/reportqueries/$METERING_NAMESPACE/$REPORTQUERY_NAME/render" \
-    --data '{"inputs": [], "start": "2020-08-25T18:53:00Z", "end": "2020-08-25T20:10:00Z"}'
+# Note: had some difficulties with evaluating environment variables in the data
+# inputs array. To avoid using my brain for something more elegant, just inject
+# the values of the start and end timestamps into the $DATA variable and reference
+# that in the `--data` argument in curl.
+printf -v DATA '{"inputs": [], "start": "%s", "end": "%s"}' $start $end
+
+curl -w '\n' \
+    -k \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $token" \
+    --data "$DATA" \
+    https://${hostname}/api/v2/reportqueries/$REPORTQUERY_NAMESPACE/$REPORTQUERY_NAME/render


### PR DESCRIPTION
Adds defaults for the start and end timestamp data. Note: this is potentially problematic in the situation where the metrics importer timestamp doesn't aligned for all the ReportDataSource queries, but should be relatively sufficient.

Updates to handle namespace arguments.